### PR TITLE
MARCXML to MODS 3.5 (XSLT 1.0 Revision 1.104)

### DIFF
--- a/xsl/MARC21slim2MODS3-5.xsl
+++ b/xsl/MARC21slim2MODS3-5.xsl
@@ -1,13 +1,15 @@
-<xsl:stylesheet xmlns="http://www.loc.gov/mods/v3" xmlns:marc="http://www.loc.gov/MARC21/slim"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	exclude-result-prefixes="xlink marc" version="1.0">
+<xsl:stylesheet xmlns="http://www.loc.gov/mods/v3" xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="xlink marc" version="1.0">
 	<xsl:include href="http://www.loc.gov/standards/marcxml/xslt/MARC21slimUtils.xsl"/>
 	<xsl:output encoding="UTF-8" indent="yes" method="xml"/>
 	<xsl:strip-space elements="*"/>
 
 	<!-- Maintenance note: For each revision, change the content of <recordInfo><recordOrigin> to reflect the new revision number.
-	MARC21slim2MODS3-5 (Revision 1.102) 20140812
+	MARC21slim2MODS3-5 (Revision 1.106) 20141219
 	
+Revision 1.106 - Added a xsl:when to deal with '#' and ' ' in $leader19 and $controlField008-18 - ws 2014/12/19		
+Revision 1.105 - Add @unit to extent - ws 2014/11/20	
+Revision 1.104 - Fixed 111$n and 711$n to reflect mapping to <namePart> tmee 20141112
+Revision 1.103 - Fixed 008/28 to reflect revised mapping for government publication tmee 20141104	
 Revision 1.102 - Fixed 240$s duplication tmee 20140812
 Revision 1.101 - Fixed 130 tmee 20140806
 Revision 1.100 - Fixed 245c tmee 20140804
@@ -115,8 +117,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	<xsl:template match="/">
 		<xsl:choose>
 			<xsl:when test="//marc:collection">
-				<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+				<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
 					<xsl:for-each select="//marc:collection/marc:record">
 						<mods version="3.5">
 							<xsl:call-template name="marcRecord"/>
@@ -125,8 +126,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</modsCollection>
 			</xsl:when>
 			<xsl:otherwise>
-				<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.5"
-					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+				<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
 					<xsl:for-each select="//marc:record">
 						<xsl:call-template name="marcRecord"/>
 					</xsl:for-each>
@@ -144,9 +144,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:choose>
 				<xsl:when test="$leader6='a'">
 					<xsl:choose>
-						<xsl:when
-							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
-							>BK</xsl:when>
+						<xsl:when test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'">BK</xsl:when>
 						<xsl:when test="$leader7='b' or $leader7='i' or $leader7='s'">SE</xsl:when>
 					</xsl:choose>
 				</xsl:when>
@@ -154,10 +152,8 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$leader6='p'">MM</xsl:when>
 				<xsl:when test="$leader6='m'">CF</xsl:when>
 				<xsl:when test="$leader6='e' or $leader6='f'">MP</xsl:when>
-				<xsl:when test="$leader6='g' or $leader6='k' or $leader6='o' or $leader6='r'"
-					>VM</xsl:when>
-				<xsl:when test="$leader6='c' or $leader6='d' or $leader6='i' or $leader6='j'"
-					>MU</xsl:when>
+				<xsl:when test="$leader6='g' or $leader6='k' or $leader6='o' or $leader6='r'">VM</xsl:when>
+				<xsl:when test="$leader6='c' or $leader6='d' or $leader6='i' or $leader6='j'">MU</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
 
@@ -219,7 +215,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					</xsl:call-template>
 				</xsl:variable>
 				<xsl:choose>
-					<xsl:when test="@ind2>0">
+					<xsl:when test="@ind2&gt;0">
 						<nonSort>
 							<xsl:value-of select="substring($titleChop,1,@ind2)"/>
 						</nonSort>
@@ -329,19 +325,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:if test="substring($controlField008,26,1)='d'">
 			<genre authority="marcgt">globe</genre>
 		</xsl:if>
-		<xsl:if
-			test="marc:controlfield[@tag='007'][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+		<xsl:if test="marc:controlfield[@tag='007'][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
 			<genre authority="marcgt">remote-sensing image</genre>
 		</xsl:if>
 		<xsl:if test="$typeOf008='MP'">
 			<xsl:variable name="controlField008-25" select="substring($controlField008,26,1)"/>
 			<xsl:choose>
-				<xsl:when
-					test="$controlField008-25='a' or $controlField008-25='b' or $controlField008-25='c' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+				<xsl:when test="$controlField008-25='a' or $controlField008-25='b' or $controlField008-25='c' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
 					<genre authority="marcgt">map</genre>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-25='e' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+				<xsl:when test="$controlField008-25='e' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
 					<genre authority="marcgt">atlas</genre>
 				</xsl:when>
 			</xsl:choose>
@@ -471,8 +464,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<genre authority="marcgt">festschrift</genre>
 			</xsl:if>
 			<xsl:variable name="controlField008-34" select="substring($controlField008,35,1)"/>
-			<xsl:if
-				test="$controlField008-34='a' or $controlField008-34='b' or $controlField008-34='c' or $controlField008-34='d'">
+			<xsl:if test="$controlField008-34='a' or $controlField008-34='b' or $controlField008-34='c' or $controlField008-34='d'">
 				<genre authority="marcgt">biography</genre>
 			</xsl:if>
 			<xsl:variable name="controlField008-33" select="substring($controlField008,34,1)"/>
@@ -593,8 +585,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$controlField008-33='p'">
 					<genre authority="marcgt">microscope slide</genre>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-33='q' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+				<xsl:when test="$controlField008-33='q' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
 					<genre authority="marcgt">model</genre>
 				</xsl:when>
 				<xsl:when test="$controlField008-33='r'">
@@ -614,6 +605,215 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:when>
 			</xsl:choose>
 		</xsl:if>
+	
+<!-- 111$n, 711$n 1.103 -->	
+		
+		<xsl:if test="$typeOf008='BK'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='CF'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='CR'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='MP'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='VM'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		
 
 		<!-- genre -->
 
@@ -631,13 +831,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<originInfo>
 			<xsl:call-template name="scriptCode"/>
-			<xsl:for-each
-				select="marc:datafield[(@tag=260 or @tag=250) and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+			<xsl:for-each select="marc:datafield[(@tag=260 or @tag=250) and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
 				<xsl:call-template name="z2xx880"/>
 			</xsl:for-each>
 
-			<xsl:variable name="MARCpublicationCode"
-				select="normalize-space(substring($controlField008,16,3))"/>
+			<xsl:variable name="MARCpublicationCode" select="normalize-space(substring($controlField008,16,3))"/>
 			<xsl:if test="translate($MARCpublicationCode,'|','')">
 				<place>
 					<placeTerm>
@@ -711,8 +909,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 
 			<!-- tmee 1.35 1.36 dateIssued/nonMSS vs dateCreated/MSS -->
-			<xsl:for-each
-				select="marc:datafield[@tag=260]/marc:subfield[@code='b' or @code='c' or @code='g']">
+			<xsl:for-each select="marc:datafield[@tag=260]/marc:subfield[@code='b' or @code='c' or @code='g']">
 				<xsl:choose>
 					<xsl:when test="@code='b'">
 						<publisher>
@@ -733,8 +930,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							</dateCreated>
 						</xsl:if>
 
-						<xsl:if
-							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+						<xsl:if test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 							<dateIssued>
 								<xsl:call-template name="chopPunctuation">
 									<xsl:with-param name="chopString" select="."/>
@@ -748,8 +944,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="."/>
 							</dateCreated>
 						</xsl:if>
-						<xsl:if
-							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+						<xsl:if test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 							<dateCreated>
 								<xsl:value-of select="."/>
 							</dateCreated>
@@ -759,23 +954,18 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 			<xsl:variable name="dataField260c">
 				<xsl:call-template name="chopPunctuation">
-					<xsl:with-param name="chopString"
-						select="marc:datafield[@tag=260]/marc:subfield[@code='c']"/>
+					<xsl:with-param name="chopString" select="marc:datafield[@tag=260]/marc:subfield[@code='c']"/>
 				</xsl:call-template>
 			</xsl:variable>
-			<xsl:variable name="controlField008-7-10"
-				select="normalize-space(substring($controlField008, 8, 4))"/>
-			<xsl:variable name="controlField008-11-14"
-				select="normalize-space(substring($controlField008, 12, 4))"/>
-			<xsl:variable name="controlField008-6"
-				select="normalize-space(substring($controlField008, 7, 1))"/>
+			<xsl:variable name="controlField008-7-10" select="normalize-space(substring($controlField008, 8, 4))"/>
+			<xsl:variable name="controlField008-11-14" select="normalize-space(substring($controlField008, 12, 4))"/>
+			<xsl:variable name="controlField008-6" select="normalize-space(substring($controlField008, 7, 1))"/>
 
 
 
 			<!-- tmee 1.35 and 1.36 and 1.84-->
 
-			<xsl:if
-				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and ($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+			<xsl:if test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and ($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
 					<dateCreated encoding="marc">
 						<xsl:value-of select="$controlField008-7-10"/>
@@ -783,16 +973,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+			<xsl:if test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
 					<dateIssued encoding="marc">
 						<xsl:value-of select="$controlField008-7-10"/></dateIssued>
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+			<xsl:if test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
 				<xsl:if test="$controlField008-7-10">
 					<dateIssued encoding="marc" point="start">
 						<xsl:value-of select="$controlField008-7-10"/>
@@ -800,8 +988,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+			<xsl:if test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
 				<xsl:if test="$controlField008-11-14">
 					<dateIssued encoding="marc" point="end">
 						<xsl:value-of select="$controlField008-11-14"/>
@@ -842,8 +1029,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					</copyrightDate>
 				</xsl:if>
 			</xsl:if>
-			<xsl:for-each
-				select="marc:datafield[@tag=033][@ind1=0 or @ind1=1]/marc:subfield[@code='a']">
+			<xsl:for-each select="marc:datafield[@tag=033][@ind1=0 or @ind1=1]/marc:subfield[@code='a']">
 				<dateCaptured encoding="iso8601">
 					<xsl:value-of select="."/>
 				</dateCaptured>
@@ -866,12 +1052,10 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:for-each select="marc:leader">
 				<issuance>
 					<xsl:choose>
-						<xsl:when
-							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
-							>monographic</xsl:when>
-						<xsl:when
-							test="$leader7='m' and ($leader19='a' or $leader19='b' or $leader19='c')"
-							>multipart monograph</xsl:when>
+						<xsl:when test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'">monographic</xsl:when>
+						<xsl:when test="$leader7='m' and ($leader19='a' or $leader19='b' or $leader19='c')">multipart monograph</xsl:when>
+						<!-- 1.106 20141218 -->
+						<xsl:when test="$leader7='m' and ($leader19=' ')">single unit</xsl:when>
 						<xsl:when test="$leader7='m' and ($leader19='#')">single unit</xsl:when>
 						<xsl:when test="$leader7='i'">integrating resource</xsl:when>
 						<xsl:when test="$leader7='b' or $leader7='s'">serial</xsl:when>
@@ -913,6 +1097,8 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:when test="$controlField008-18='t'">Three times a year</xsl:when>
 								<xsl:when test="$controlField008-18='u'">Unknown</xsl:when>
 								<xsl:when test="$controlField008-18='w'">Weekly</xsl:when>
+								<!-- 1.106 20141218 -->
+								<xsl:when test="$controlField008-18=' '">Completely irregular</xsl:when>
 								<xsl:when test="$controlField008-18='#'">Completely irregular</xsl:when>
 								<xsl:otherwise/>
 							</xsl:choose>
@@ -1000,23 +1186,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</xsl:for-each>
 
 
-
-
-
 		<xsl:for-each select="marc:datafield[@tag=880]">
-			<xsl:variable name="related_datafield"
-				select="substring-before(marc:subfield[@code='6'],'-')"/>
-			<xsl:variable name="occurence_number"
-				select="substring( substring-after(marc:subfield[@code='6'],'-') , 1 , 2 )"/>
-			<xsl:variable name="hit"
-				select="../marc:datafield[@tag=$related_datafield and contains(marc:subfield[@code='6'] , concat('880-' , $occurence_number))]/@tag"/>
+			<xsl:variable name="related_datafield" select="substring-before(marc:subfield[@code='6'],'-')"/>
+			<xsl:variable name="occurence_number" select="substring( substring-after(marc:subfield[@code='6'],'-') , 1 , 2 )"/>
+			<xsl:variable name="hit" select="../marc:datafield[@tag=$related_datafield and contains(marc:subfield[@code='6'] , concat('880-' , $occurence_number))]/@tag"/>
 
 			<xsl:choose>
 				<xsl:when test="$hit='260'">
 					<originInfo>
 						<xsl:call-template name="scriptCode"/>
-						<xsl:for-each
-							select="../marc:datafield[@tag=260 and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+						<xsl:for-each select="../marc:datafield[@tag=260 and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
 							<xsl:call-template name="z2xx880"/>
 						</xsl:for-each>
 						<xsl:if test="marc:subfield[@code='a']">
@@ -1041,8 +1220,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="marc:subfield[@code='g']"/>
 							</dateCreated>
 						</xsl:if>
-						<xsl:for-each
-							select="../marc:datafield[@tag=880]/marc:subfield[@code=6][contains(text(),'250')]">
+						<xsl:for-each select="../marc:datafield[@tag=880]/marc:subfield[@code=6][contains(text(),'250')]">
 							<edition>
 								<xsl:value-of select="following-sibling::marc:subfield"/>
 							</edition>
@@ -1072,15 +1250,13 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:with-param name="codes">a</xsl:with-param>
 							</xsl:call-template>
 						</form>
-	
 					</physicalDescription>
 				</xsl:when>
 			</xsl:choose>
 		</xsl:for-each>
 
 		<!-- language 041 -->
-		<xsl:variable name="controlField008-35-37"
-			select="normalize-space(translate(substring($controlField008,36,3),'|#',''))"/>
+		<xsl:variable name="controlField008-35-37" select="normalize-space(translate(substring($controlField008,36,3),'|#',''))"/>
 		<xsl:if test="$controlField008-35-37">
 			<language>
 				<languageTerm authority="iso639-2b" type="code">
@@ -1089,8 +1265,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</language>
 		</xsl:if>
 		<xsl:for-each select="marc:datafield[@tag=041]">
-			<xsl:for-each
-				select="marc:subfield[@code='a' or @code='b' or @code='d' or @code='e' or @code='f' or @code='g' or @code='h']">
+			<xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='d' or @code='e' or @code='f' or @code='g' or @code='h']">
 				<xsl:variable name="langCodes" select="."/>
 				<xsl:choose>
 					<xsl:when test="../marc:subfield[@code='2']='rfc3066'">
@@ -1120,9 +1295,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="substring($allLanguages,1,3)"/>
 							</xsl:with-param>
 							<xsl:with-param name="remainingLanguages">
-								<xsl:value-of
-									select="substring($allLanguages,4,string-length($allLanguages)-3)"
-								/>
+								<xsl:value-of select="substring($allLanguages,4,string-length($allLanguages)-3)"/>
 							</xsl:with-param>
 							<xsl:with-param name="usedLanguages">
 								<xsl:if test="$controlField008-35-37">
@@ -1151,8 +1324,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:variable name="controlField008-23" select="substring($controlField008,24,1)"/>
 			<xsl:variable name="controlField008-29" select="substring($controlField008,30,1)"/>
 			<xsl:variable name="check008-23">
-				<xsl:if
-					test="$typeOf008='BK' or $typeOf008='MU' or $typeOf008='SE' or $typeOf008='MM'">
+				<xsl:if test="$typeOf008='BK' or $typeOf008='MU' or $typeOf008='SE' or $typeOf008='MM'">
 					<xsl:value-of select="true()"/>
 				</xsl:if>
 			</xsl:variable>
@@ -1162,28 +1334,23 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:variable>
 			<xsl:choose>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='f') or ($check008-29 and $controlField008-29='f')">
+				<xsl:when test="($check008-23 and $controlField008-23='f') or ($check008-29 and $controlField008-29='f')">
 					<form authority="marcform">braille</form>
 				</xsl:when>
-				<xsl:when
-					test="($controlField008-23=' ' and ($leader6='c' or $leader6='d')) or (($typeOf008='BK' or $typeOf008='SE') and ($controlField008-23=' ' or $controlField008='r'))">
+				<xsl:when test="($controlField008-23=' ' and ($leader6='c' or $leader6='d')) or (($typeOf008='BK' or $typeOf008='SE') and ($controlField008-23=' ' or $controlField008='r'))">
 					<form authority="marcform">print</form>
 				</xsl:when>
-				<xsl:when
-					test="$leader6 = 'm' or ($check008-23 and $controlField008-23='s') or ($check008-29 and $controlField008-29='s')">
+				<xsl:when test="$leader6 = 'm' or ($check008-23 and $controlField008-23='s') or ($check008-29 and $controlField008-29='s')">
 					<form authority="marcform">electronic</form>
 				</xsl:when>
 				<!-- 1.33 -->
 				<xsl:when test="$leader6 = 'o'">
 					<form authority="marcform">kit</form>
 				</xsl:when>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='b') or ($check008-29 and $controlField008-29='b')">
+				<xsl:when test="($check008-23 and $controlField008-23='b') or ($check008-29 and $controlField008-29='b')">
 					<form authority="marcform">microfiche</form>
 				</xsl:when>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='a') or ($check008-29 and $controlField008-29='a')">
+				<xsl:when test="($check008-23 and $controlField008-23='a') or ($check008-29 and $controlField008-29='a')">
 					<form authority="marcform">microfilm</form>
 				</xsl:when>
 			</xsl:choose>
@@ -1193,8 +1360,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=130]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=130]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1203,8 +1369,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=240]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=240]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1213,8 +1378,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=242]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=242]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1223,8 +1387,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=245]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=245]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1233,8 +1396,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=246]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=246]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1243,8 +1405,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=730]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=730]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1268,367 +1429,295 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:choose>
 			</xsl:for-each>
 			<!--3.2 change tmee 007/01 -->
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='b']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">chip cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='c']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">computer optical disc cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='j']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">magnetic disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='m']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='m']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">magneto-optical disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='o']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">optical disc</form>
 			</xsl:if>
 
 			<!-- 1.38 AQ 1.29 tmee 	1.66 added marccategory and marcsmd as part of 3.4 -->
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='r']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">remote</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='a']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='f']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='h']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='h']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='a']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">celestial globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='e']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">earth moon globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='b']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">planetary or lunar globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='c']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">terrestrial globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='o'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='o'][substring(text(),2,1)='o']">
 				<form authority="marccategory">kit</form>
 				<form authority="marcsmd">kit</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">atlas</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='g']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">diagram</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">map</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">model</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='k']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='k']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">profile</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
 				<form authority="marcsmd">remote-sensing image</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='s']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">section</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='y']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='y']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">view</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='a']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">aperture card</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='e']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfiche</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='f']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfiche cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='b']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='c']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='d']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='g']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microopaque</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='c']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='f']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='r']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='n']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='n']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">chart</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='c']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">collage</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='d']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">drawing</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='o']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">flash card</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='e']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">painting</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='f']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photomechanical print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='g']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photonegative</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='h']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='h']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photoprint</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='i']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='i']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">picture</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='j']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='l']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='l']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">technical drawing</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='q'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='q'][substring(text(),2,1)='q']">
 				<form authority="marccategory">notated music</form>
 				<form authority="marcsmd">notated music</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='d']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmslip</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='c']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmstrip cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='o']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmstrip roll</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='f']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">other filmstrip type</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='s']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">slide</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='t']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='t']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">transparency</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='r'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='r'][substring(text(),2,1)='r']">
 				<form authority="marccategory">remote-sensing image</form>
 				<form authority="marcsmd">remote-sensing image</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='e']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">cylinder</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='q']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">roll</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='g']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='s']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='d']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='t']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='t']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound-tape reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='i']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='i']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound-track film</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='w']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='w']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">wire recording</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='c']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">braille</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='b']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">combination</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='a']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">moon</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='d']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">tactile, with no writing system</form>
 			</xsl:if>
 
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='c']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">braille</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='b']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">large print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='a']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">regular print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='d']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">text in looseleaf binder</form>
 			</xsl:if>
 
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='c']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videocartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='f']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videocassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='d']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videodisc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='r']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videoreel</form>
 			</xsl:if>
 
-			<xsl:for-each
-				select="marc:datafield[@tag=856]/marc:subfield[@code='q'][string-length(.)&gt;1]">
+			<xsl:for-each select="marc:datafield[@tag=856]/marc:subfield[@code='q'][string-length(.)&gt;1]">
 				<internetMediaType>
 					<xsl:value-of select="."/>
 				</internetMediaType>
@@ -1636,8 +1725,15 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 			<xsl:for-each select="marc:datafield[@tag=300]">
 				<extent>
+					<xsl:if test="marc:subfield[@code='f']">
+						<xsl:attribute name="unit">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">f</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
 					<xsl:call-template name="subfieldSelect">
-						<xsl:with-param name="codes">abce3fg</xsl:with-param>
+						<xsl:with-param name="codes">abce3g</xsl:with-param>
 					</xsl:call-template>
 				</extent>
 			</xsl:for-each>
@@ -1736,8 +1832,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$controlField008-22='g'">
 					<targetAudience authority="marctarget">general</targetAudience>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-22='b' or $controlField008-22='c' or $controlField008-22='j'">
+				<xsl:when test="$controlField008-22='b' or $controlField008-22='c' or $controlField008-22='j'">
 					<targetAudience authority="marctarget">juvenile</targetAudience>
 				</xsl:when>
 				<xsl:when test="$controlField008-22='a'">
@@ -1863,8 +1958,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="createNoteFrom585"/>
 		</xsl:for-each>
 
-		<xsl:for-each
-			select="marc:datafield[@tag=501 or @tag=507 or @tag=513 or @tag=514 or @tag=516 or @tag=522 or @tag=525 or @tag=526 or @tag=544 or @tag=547 or @tag=550 or @tag=552 or @tag=555 or @tag=556 or @tag=565 or @tag=567 or @tag=580 or @tag=584 or @tag=586]">
+		<xsl:for-each select="marc:datafield[@tag=501 or @tag=507 or @tag=513 or @tag=514 or @tag=516 or @tag=522 or @tag=525 or @tag=526 or @tag=544 or @tag=547 or @tag=550 or @tag=552 or @tag=555 or @tag=556 or @tag=565 or @tag=567 or @tag=580 or @tag=584 or @tag=586]">
 			<xsl:call-template name="createNoteFrom5XX"/>
 		</xsl:for-each>
 
@@ -2205,8 +2299,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<!-- AQ1.5, AQ1.7 deleted tags 777 and 787 from the following select for relatedItem mapping -->
 		<!-- 1.45 and 1.46 - AQ1.24 and 1.25 tmee-->
-		<xsl:for-each
-			select="marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=775]">
+		<xsl:for-each select="marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=775]">
 			<relatedItem type="otherVersion">
 				<xsl:call-template name="relatedItem76X-78X"/>
 			</relatedItem>
@@ -2490,21 +2583,17 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</identifier>
 		</xsl:for-each>
 
-		<xsl:for-each
-			select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(OCoLC)')]]">
+		<xsl:for-each select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(OCoLC)')]]">
 			<identifier type="oclc">
-				<xsl:value-of
-					select="normalize-space(substring-after(marc:subfield[@code='a'], '(OCoLC)'))"/>
+				<xsl:value-of select="normalize-space(substring-after(marc:subfield[@code='a'], '(OCoLC)'))"/>
 			</identifier>
 		</xsl:for-each>
 		
 		
 		<!-- 3.5 1.95 20140421 -->
-		<xsl:for-each
-			select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(WlCaITV)')]]">
+		<xsl:for-each select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(WlCaITV)')]]">
 			<identifier type="WlCaITV">
-				<xsl:value-of
-					select="normalize-space(substring-after(marc:subfield[@code='a'], '(WlCaITV)'))"/>
+				<xsl:value-of select="normalize-space(substring-after(marc:subfield[@code='a'], '(WlCaITV)'))"/>
 			</identifier>
 		</xsl:for-each>
 
@@ -2526,24 +2615,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<!-- 1.51 tmee 20100129-->
 		<xsl:for-each select="marc:datafield[@tag='856'][marc:subfield[@code='u']]">
-			<xsl:if
-				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
+			<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
 				<identifier>
 					<xsl:attribute name="type">
-						<xsl:if
-							test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')"
-							>doi</xsl:if>
-						<xsl:if
-							test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')"
-							>hdl</xsl:if>
+						<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')">doi</xsl:if>
+						<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')">hdl</xsl:if>
 					</xsl:attribute>
-					<xsl:value-of
-						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
-					/>
+					<xsl:value-of select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"/>
 				</identifier>
 			</xsl:if>
-			<xsl:if
-				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
+			<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
 				<identifier type="hdl">
 					<xsl:if test="marc:subfield[@code='y' or @code='3' or @code='z']">
 						<xsl:attribute name="displayLabel">
@@ -2552,9 +2633,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							</xsl:call-template>
 						</xsl:attribute>
 					</xsl:if>
-					<xsl:value-of
-						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
-					/>
+					<xsl:value-of select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"/>
 				</identifier>
 			</xsl:if>
 		</xsl:for-each>
@@ -2666,7 +2745,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 
 			<recordOrigin>Converted from MARCXML to MODS version 3.5 using MARC21slim2MODS3-5.xsl
-				(Revision 1.102 2014/08/12)</recordOrigin>
+				(Revision 1.106 2014/12/19)</recordOrigin>
 
 			<xsl:for-each select="marc:datafield[@tag=040]/marc:subfield[@code='b']">
 				<languageOfCataloging>
@@ -2926,8 +3005,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:value-of select="."/>
 			</namePart>
 		</xsl:for-each>
-		<xsl:if
-			test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+		<xsl:if test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
 			<namePart>
 				<xsl:call-template name="subfieldSelect">
 					<xsl:with-param name="codes">cdn</xsl:with-param>
@@ -2958,6 +3036,18 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:call-template>
 		</namePart>
 	</xsl:template>
+	
+	<!--1.104 20141104-->
+	<xsl:template name="nameACDENQ">
+		<namePart>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">acdenq</xsl:with-param>
+			</xsl:call-template>
+		</namePart>
+	</xsl:template>
+	
+	
+	
 	<xsl:template name="constituentOrRelatedType">
 		<xsl:if test="@ind2=2">
 			<xsl:attribute name="type">constituent</xsl:attribute>
@@ -3155,8 +3245,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:param name="afterCodes"/>
 		<xsl:variable name="str">
 			<xsl:for-each select="marc:subfield">
-				<xsl:if
-					test="contains($anyCodes, @code) or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+				<xsl:if test="contains($anyCodes, @code) or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
 					<xsl:value-of select="text()"/>
 					<xsl:text> </xsl:text>
 				</xsl:if>
@@ -3427,9 +3516,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
 					</xsl:with-param>
 					<xsl:with-param name="remainingLanguages">
-						<xsl:value-of
-							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
-						/>
+						<xsl:value-of select="substring($remainingLanguages,4,string-length($remainingLanguages))"/>
 					</xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>
@@ -3442,9 +3529,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
 					</xsl:with-param>
 					<xsl:with-param name="remainingLanguages">
-						<xsl:value-of
-							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
-						/>
+						<xsl:value-of select="substring($remainingLanguages,4,string-length($remainingLanguages))"/>
 					</xsl:with-param>
 				</xsl:call-template>
 			</xsl:otherwise>
@@ -3471,8 +3556,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="currentLanguage" select="."/>
 		<xsl:choose>
 			<xsl:when test="not($currentLanguage)"/>
-			<xsl:when
-				test="$currentLanguage!=$controlField008-35-37 and $currentLanguage!='rfc3066'">
+			<xsl:when test="$currentLanguage!=$controlField008-35-37 and $currentLanguage!='rfc3066'">
 				<xsl:if test="not(contains($usedLanguages,$currentLanguage))">
 					<language>
 						<xsl:if test="@code!='a'">
@@ -3571,8 +3655,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 	<xsl:template name="yyy880">
 		<xsl:if test="preceding-sibling::marc:subfield[@code='6']">
-			<xsl:variable name="sf06"
-				select="normalize-space(preceding-sibling::marc:subfield[@code='6'])"/>
+			<xsl:variable name="sf06" select="normalize-space(preceding-sibling::marc:subfield[@code='6'])"/>
 			<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
 			<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
 			<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
@@ -3589,17 +3672,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x260">
 			<xsl:choose>
 				<xsl:when test="@tag='260' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06260"
-						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06260" select="normalize-space(child::marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
 					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
 					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
 					<xsl:value-of select="$sf06260b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='250' and ../marc:datafield[@tag='260']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06260"
-						select="normalize-space(../marc:datafield[@tag='260']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='250' and ../marc:datafield[@tag='260']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06260" select="normalize-space(../marc:datafield[@tag='260']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
 					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
 					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
@@ -3611,17 +3691,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x250">
 			<xsl:choose>
 				<xsl:when test="@tag='250' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06250"
-						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06250" select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
 					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
 					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
 					<xsl:value-of select="$sf06250b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='260' and ../marc:datafield[@tag='250']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06250"
-						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='260' and ../marc:datafield[@tag='250']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06250" select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
 					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
 					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
@@ -3655,17 +3732,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x300">
 			<xsl:choose>
 				<xsl:when test="@tag='300' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06300"
-						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06300" select="normalize-space(child::marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
 					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
 					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
 					<xsl:value-of select="$sf06300b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='351' and ../marc:datafield[@tag='300']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06300"
-						select="normalize-space(../marc:datafield[@tag='300']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='351' and ../marc:datafield[@tag='300']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06300" select="normalize-space(../marc:datafield[@tag='300']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
 					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
 					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
@@ -3677,17 +3751,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x351">
 			<xsl:choose>
 				<xsl:when test="@tag='351' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06351"
-						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06351" select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
 					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
 					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
 					<xsl:value-of select="$sf06351b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='300' and ../marc:datafield[@tag='351']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06351"
-						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='300' and ../marc:datafield[@tag='351']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06351" select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
 					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
 					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
@@ -3698,8 +3769,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<xsl:variable name="x337">
 			<xsl:if test="@tag='337' and marc:subfield[@code='6']">
-				<xsl:variable name="sf06337"
-					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06337" select="normalize-space(child::marc:subfield[@code='6'])"/>
 				<xsl:variable name="sf06337a" select="substring($sf06337, 1, 3)"/>
 				<xsl:variable name="sf06337b" select="substring($sf06337, 5, 2)"/>
 				<xsl:variable name="sf06337c" select="substring($sf06337, 7)"/>
@@ -3708,8 +3778,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</xsl:variable>
 		<xsl:variable name="x338">
 			<xsl:if test="@tag='338' and marc:subfield[@code='6']">
-				<xsl:variable name="sf06338"
-					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06338" select="normalize-space(child::marc:subfield[@code='6'])"/>
 				<xsl:variable name="sf06338a" select="substring($sf06338, 1, 3)"/>
 				<xsl:variable name="sf06338b" select="substring($sf06338, 5, 2)"/>
 				<xsl:variable name="sf06338c" select="substring($sf06338, 7)"/>
@@ -4065,8 +4134,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="text()"/>
 								<xsl:text> </xsl:text>
 							</xsl:if>
-							<xsl:if
-								test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+							<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 								<xsl:value-of select="text()"/>
 								<xsl:text> </xsl:text>
 							</xsl:if>
@@ -4091,8 +4159,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
-						<xsl:if
-							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+						<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
@@ -4216,8 +4283,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 	<xsl:template name="createTitleInfoFrom240">
 		<titleInfo type="uniform">
-			<xsl:if
-				test="//marc:datafield[@tag='100']|//marc:datafield[@tag='110']|//marc:datafield[@tag='111']">
+			<xsl:if test="//marc:datafield[@tag='100']|//marc:datafield[@tag='110']|//marc:datafield[@tag='111']">
 				<xsl:attribute name="nameTitleGroup">
 					<xsl:text>1</xsl:text>
 				</xsl:attribute>
@@ -4226,8 +4292,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<title>
 				<xsl:variable name="str">
 					<xsl:for-each select="marc:subfield">
-						<xsl:if
-							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+						<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
@@ -4311,6 +4376,9 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</name>
 	</xsl:template>
 
+
+	<!-- 111 1.104 20141104 -->
+
 	<xsl:template name="createNameFrom111">
 		<name type="conference">
 			<xsl:call-template name="xxx880"/>
@@ -4319,7 +4387,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					<xsl:text>1</xsl:text>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="nameACDENQ"/>
 			<xsl:call-template name="role"/>
 		</name>
 	</xsl:template>
@@ -4355,10 +4423,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</name>
 	</xsl:template>
 
+<!-- 111 1.104 20141104 -->
 	<xsl:template name="createNameFrom711">
 		<name type="conference">
 			<xsl:call-template name="xxx880"/>
-			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="nameACDENQ"/>
 			<xsl:call-template name="role"/>
 		</name>
 	</xsl:template>
@@ -4569,8 +4638,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="xxx880"/>
 			<xsl:call-template name="uri"/>
 			<xsl:variable name="str">
-				<xsl:for-each
-					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+				<xsl:for-each select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
 					<xsl:value-of select="."/>
 					<xsl:text> </xsl:text>
 				</xsl:for-each>
@@ -4640,8 +4708,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="xxx880"/>
 			<xsl:call-template name="uri"/>
 			<xsl:variable name="str">
-				<xsl:for-each
-					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+				<xsl:for-each select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
 					<xsl:value-of select="."/>
 					<xsl:text> </xsl:text>
 				</xsl:for-each>
@@ -4851,8 +4918,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	<!-- subject Geo 034 043 045 255 656 662 752 -->
 
 	<xsl:template name="createSubGeoFrom034">
-		<xsl:if
-			test="marc:datafield[@tag=034][marc:subfield[@code='d' or @code='e' or @code='f' or @code='g']]">
+		<xsl:if test="marc:datafield[@tag=034][marc:subfield[@code='d' or @code='e' or @code='f' or @code='g']]">
 			<subject>
 				<xsl:call-template name="xxx880"/>
 				<cartographics>
@@ -5256,20 +5322,17 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	</xsl:template>
 
 	<xsl:template name="createSubTemFrom045">
-		<xsl:if
-			test="//marc:datafield[@tag=045 and @ind1='2'][marc:subfield[@code='b' or @code='c']]">
+		<xsl:if test="//marc:datafield[@tag=045 and @ind1='2'][marc:subfield[@code='b' or @code='c']]">
 			<subject>
 				<xsl:call-template name="xxx880"/>
 				<temporal encoding="iso8601" point="start">
 					<xsl:call-template name="dates045b">
-						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][1]"
-						/>
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][1]"/>
 					</xsl:call-template>
 				</temporal>
 				<temporal encoding="iso8601" point="end">
 					<xsl:call-template name="dates045b">
-						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][2]"
-						/>
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][2]"/>
 					</xsl:call-template>
 				</temporal>
 			</subject>
@@ -5292,8 +5355,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:value-of select="text()"/>
 			</classification>
 		</xsl:for-each>
-		<xsl:for-each
-			select="marc:subfield[@code='a'][not(following-sibling::marc:subfield[@code='b'])]">
+		<xsl:for-each select="marc:subfield[@code='a'][not(following-sibling::marc:subfield[@code='b'])]">
 			<classification authority="lcc">
 				<xsl:call-template name="xxx880"/>
 				<xsl:if test="../marc:subfield[@code='3']">
@@ -5412,8 +5474,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</physicalLocation>
 			</xsl:if>
 			<!-- 1.78 -->
-			<xsl:if
-				test="marc:subfield[@code='h' or @code='i' or @code='j' or @code='k' or @code='l' or @code='m' or @code='t']">
+			<xsl:if test="marc:subfield[@code='h' or @code='i' or @code='j' or @code='k' or @code='l' or @code='m' or @code='t']">
 				<shelfLocator>
 					<xsl:call-template name="subfieldSelect">
 						<xsl:with-param name="codes">hijklmt</xsl:with-param>
@@ -5430,23 +5491,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					<!-- 1.41 tmee AQ1.9 added choice protocol for @usage="primary display" -->
 					<xsl:variable name="primary">
 						<xsl:choose>
-							<xsl:when
-								test="@ind2=0 and count(preceding-sibling::marc:datafield[@tag=856] [@ind2=0])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2=0 and count(preceding-sibling::marc:datafield[@tag=856] [@ind2=0])=0">true</xsl:when>
 
-							<xsl:when
-								test="@ind2=1 and 
-							count(ancestor::marc:record//marc:datafield[@tag=856][@ind2=0])=0 and 
-							count(preceding-sibling::marc:datafield[@tag=856][@ind2=1])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2=1 and         count(ancestor::marc:record//marc:datafield[@tag=856][@ind2=0])=0 and         count(preceding-sibling::marc:datafield[@tag=856][@ind2=1])=0">true</xsl:when>
 
-							<xsl:when
-								test="@ind2!=1 and @ind2!=0 and 
-							@ind2!=2 and count(ancestor::marc:record//marc:datafield[@tag=856 and 
-							@ind2=0])=0 and count(ancestor::marc:record//marc:datafield[@tag=856 and 
-							@ind2=1])=0 and 
-							count(preceding-sibling::marc:datafield[@tag=856][@ind2])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2!=1 and @ind2!=0 and         @ind2!=2 and count(ancestor::marc:record//marc:datafield[@tag=856 and         @ind2=0])=0 and count(ancestor::marc:record//marc:datafield[@tag=856 and         @ind2=1])=0 and         count(preceding-sibling::marc:datafield[@tag=856][@ind2])=0">true</xsl:when>
 							<xsl:otherwise>false</xsl:otherwise>
 						</xsl:choose>
 					</xsl:variable>

--- a/xsl/MARC21slim2MODS3-5.xsl
+++ b/xsl/MARC21slim2MODS3-5.xsl
@@ -1,13 +1,14 @@
-<xsl:stylesheet xmlns="http://www.loc.gov/mods/v3" xmlns:marc="http://www.loc.gov/MARC21/slim"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	exclude-result-prefixes="xlink marc" version="1.0">
+<xsl:stylesheet xmlns="http://www.loc.gov/mods/v3" xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="xlink marc" version="1.0">
 	<xsl:include href="http://www.loc.gov/standards/marcxml/xslt/MARC21slimUtils.xsl"/>
 	<xsl:output encoding="UTF-8" indent="yes" method="xml"/>
 	<xsl:strip-space elements="*"/>
 
 	<!-- Maintenance note: For each revision, change the content of <recordInfo><recordOrigin> to reflect the new revision number.
-	MARC21slim2MODS3-5 (Revision 1.102) 20140812
+	MARC21slim2MODS3-5 (Revision 1.105) 20141121
 	
+Revision 1.105 - Add @unit to extent - ws 2014/11/20	
+Revision 1.104 - Fixed 111$n and 711$n to reflect mapping to <namePart> tmee 20141112
+Revision 1.103 - Fixed 008/28 to reflect revised mapping for government publication tmee 20141104	
 Revision 1.102 - Fixed 240$s duplication tmee 20140812
 Revision 1.101 - Fixed 130 tmee 20140806
 Revision 1.100 - Fixed 245c tmee 20140804
@@ -115,8 +116,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	<xsl:template match="/">
 		<xsl:choose>
 			<xsl:when test="//marc:collection">
-				<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+				<modsCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
 					<xsl:for-each select="//marc:collection/marc:record">
 						<mods version="3.5">
 							<xsl:call-template name="marcRecord"/>
@@ -125,8 +125,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</modsCollection>
 			</xsl:when>
 			<xsl:otherwise>
-				<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.5"
-					xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+				<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
 					<xsl:for-each select="//marc:record">
 						<xsl:call-template name="marcRecord"/>
 					</xsl:for-each>
@@ -144,9 +143,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:choose>
 				<xsl:when test="$leader6='a'">
 					<xsl:choose>
-						<xsl:when
-							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
-							>BK</xsl:when>
+						<xsl:when test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'">BK</xsl:when>
 						<xsl:when test="$leader7='b' or $leader7='i' or $leader7='s'">SE</xsl:when>
 					</xsl:choose>
 				</xsl:when>
@@ -154,10 +151,8 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$leader6='p'">MM</xsl:when>
 				<xsl:when test="$leader6='m'">CF</xsl:when>
 				<xsl:when test="$leader6='e' or $leader6='f'">MP</xsl:when>
-				<xsl:when test="$leader6='g' or $leader6='k' or $leader6='o' or $leader6='r'"
-					>VM</xsl:when>
-				<xsl:when test="$leader6='c' or $leader6='d' or $leader6='i' or $leader6='j'"
-					>MU</xsl:when>
+				<xsl:when test="$leader6='g' or $leader6='k' or $leader6='o' or $leader6='r'">VM</xsl:when>
+				<xsl:when test="$leader6='c' or $leader6='d' or $leader6='i' or $leader6='j'">MU</xsl:when>
 			</xsl:choose>
 		</xsl:variable>
 
@@ -219,7 +214,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					</xsl:call-template>
 				</xsl:variable>
 				<xsl:choose>
-					<xsl:when test="@ind2>0">
+					<xsl:when test="@ind2&gt;0">
 						<nonSort>
 							<xsl:value-of select="substring($titleChop,1,@ind2)"/>
 						</nonSort>
@@ -329,19 +324,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:if test="substring($controlField008,26,1)='d'">
 			<genre authority="marcgt">globe</genre>
 		</xsl:if>
-		<xsl:if
-			test="marc:controlfield[@tag='007'][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+		<xsl:if test="marc:controlfield[@tag='007'][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
 			<genre authority="marcgt">remote-sensing image</genre>
 		</xsl:if>
 		<xsl:if test="$typeOf008='MP'">
 			<xsl:variable name="controlField008-25" select="substring($controlField008,26,1)"/>
 			<xsl:choose>
-				<xsl:when
-					test="$controlField008-25='a' or $controlField008-25='b' or $controlField008-25='c' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+				<xsl:when test="$controlField008-25='a' or $controlField008-25='b' or $controlField008-25='c' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
 					<genre authority="marcgt">map</genre>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-25='e' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+				<xsl:when test="$controlField008-25='e' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
 					<genre authority="marcgt">atlas</genre>
 				</xsl:when>
 			</xsl:choose>
@@ -471,8 +463,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<genre authority="marcgt">festschrift</genre>
 			</xsl:if>
 			<xsl:variable name="controlField008-34" select="substring($controlField008,35,1)"/>
-			<xsl:if
-				test="$controlField008-34='a' or $controlField008-34='b' or $controlField008-34='c' or $controlField008-34='d'">
+			<xsl:if test="$controlField008-34='a' or $controlField008-34='b' or $controlField008-34='c' or $controlField008-34='d'">
 				<genre authority="marcgt">biography</genre>
 			</xsl:if>
 			<xsl:variable name="controlField008-33" select="substring($controlField008,34,1)"/>
@@ -593,8 +584,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$controlField008-33='p'">
 					<genre authority="marcgt">microscope slide</genre>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-33='q' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+				<xsl:when test="$controlField008-33='q' or marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
 					<genre authority="marcgt">model</genre>
 				</xsl:when>
 				<xsl:when test="$controlField008-33='r'">
@@ -614,6 +604,215 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:when>
 			</xsl:choose>
 		</xsl:if>
+	
+<!-- 111$n, 711$n 1.103 -->	
+		
+		<xsl:if test="$typeOf008='BK'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='CF'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='CR'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='MP'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		<xsl:if test="$typeOf008='VM'">
+			<xsl:variable name="controlField008-28" select="substring($controlField008,29,1)"/>
+			<xsl:choose>
+				<xsl:when test="contains($controlField008-28,'a')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'c')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'f')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'i')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'l')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'m')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'o')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'s')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'u')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'z')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+				<xsl:when test="contains($controlField008-28,'|')">
+					<genre authority="marcgt">government publication</genre>
+				</xsl:when>
+			</xsl:choose>
+		</xsl:if>
+		
 
 		<!-- genre -->
 
@@ -631,13 +830,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<originInfo>
 			<xsl:call-template name="scriptCode"/>
-			<xsl:for-each
-				select="marc:datafield[(@tag=260 or @tag=250) and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+			<xsl:for-each select="marc:datafield[(@tag=260 or @tag=250) and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
 				<xsl:call-template name="z2xx880"/>
 			</xsl:for-each>
 
-			<xsl:variable name="MARCpublicationCode"
-				select="normalize-space(substring($controlField008,16,3))"/>
+			<xsl:variable name="MARCpublicationCode" select="normalize-space(substring($controlField008,16,3))"/>
 			<xsl:if test="translate($MARCpublicationCode,'|','')">
 				<place>
 					<placeTerm>
@@ -711,8 +908,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 
 			<!-- tmee 1.35 1.36 dateIssued/nonMSS vs dateCreated/MSS -->
-			<xsl:for-each
-				select="marc:datafield[@tag=260]/marc:subfield[@code='b' or @code='c' or @code='g']">
+			<xsl:for-each select="marc:datafield[@tag=260]/marc:subfield[@code='b' or @code='c' or @code='g']">
 				<xsl:choose>
 					<xsl:when test="@code='b'">
 						<publisher>
@@ -733,8 +929,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							</dateCreated>
 						</xsl:if>
 
-						<xsl:if
-							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+						<xsl:if test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 							<dateIssued>
 								<xsl:call-template name="chopPunctuation">
 									<xsl:with-param name="chopString" select="."/>
@@ -748,8 +943,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="."/>
 							</dateCreated>
 						</xsl:if>
-						<xsl:if
-							test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+						<xsl:if test="not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 							<dateCreated>
 								<xsl:value-of select="."/>
 							</dateCreated>
@@ -759,23 +953,18 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 			<xsl:variable name="dataField260c">
 				<xsl:call-template name="chopPunctuation">
-					<xsl:with-param name="chopString"
-						select="marc:datafield[@tag=260]/marc:subfield[@code='c']"/>
+					<xsl:with-param name="chopString" select="marc:datafield[@tag=260]/marc:subfield[@code='c']"/>
 				</xsl:call-template>
 			</xsl:variable>
-			<xsl:variable name="controlField008-7-10"
-				select="normalize-space(substring($controlField008, 8, 4))"/>
-			<xsl:variable name="controlField008-11-14"
-				select="normalize-space(substring($controlField008, 12, 4))"/>
-			<xsl:variable name="controlField008-6"
-				select="normalize-space(substring($controlField008, 7, 1))"/>
+			<xsl:variable name="controlField008-7-10" select="normalize-space(substring($controlField008, 8, 4))"/>
+			<xsl:variable name="controlField008-11-14" select="normalize-space(substring($controlField008, 12, 4))"/>
+			<xsl:variable name="controlField008-6" select="normalize-space(substring($controlField008, 7, 1))"/>
 
 
 
 			<!-- tmee 1.35 and 1.36 and 1.84-->
 
-			<xsl:if
-				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and ($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+			<xsl:if test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and ($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
 					<dateCreated encoding="marc">
 						<xsl:value-of select="$controlField008-7-10"/>
@@ -783,16 +972,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
+			<xsl:if test="($controlField008-6='e' or $controlField008-6='p' or $controlField008-6='r' or $controlField008-6='s' or $controlField008-6='t') and not($leader6='d' or $leader6='f' or $leader6='p' or $leader6='t')">
 				<xsl:if test="$controlField008-7-10 and ($controlField008-7-10 != $dataField260c)">
 					<dateIssued encoding="marc">
 						<xsl:value-of select="$controlField008-7-10"/></dateIssued>
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+			<xsl:if test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
 				<xsl:if test="$controlField008-7-10">
 					<dateIssued encoding="marc" point="start">
 						<xsl:value-of select="$controlField008-7-10"/>
@@ -800,8 +987,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:if>
 
-			<xsl:if
-				test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
+			<xsl:if test="$controlField008-6='c' or $controlField008-6='d' or $controlField008-6='i' or $controlField008-6='k' or $controlField008-6='m' or $controlField008-6='u'">
 				<xsl:if test="$controlField008-11-14">
 					<dateIssued encoding="marc" point="end">
 						<xsl:value-of select="$controlField008-11-14"/>
@@ -842,8 +1028,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					</copyrightDate>
 				</xsl:if>
 			</xsl:if>
-			<xsl:for-each
-				select="marc:datafield[@tag=033][@ind1=0 or @ind1=1]/marc:subfield[@code='a']">
+			<xsl:for-each select="marc:datafield[@tag=033][@ind1=0 or @ind1=1]/marc:subfield[@code='a']">
 				<dateCaptured encoding="iso8601">
 					<xsl:value-of select="."/>
 				</dateCaptured>
@@ -866,12 +1051,8 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:for-each select="marc:leader">
 				<issuance>
 					<xsl:choose>
-						<xsl:when
-							test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'"
-							>monographic</xsl:when>
-						<xsl:when
-							test="$leader7='m' and ($leader19='a' or $leader19='b' or $leader19='c')"
-							>multipart monograph</xsl:when>
+						<xsl:when test="$leader7='a' or $leader7='c' or $leader7='d' or $leader7='m'">monographic</xsl:when>
+						<xsl:when test="$leader7='m' and ($leader19='a' or $leader19='b' or $leader19='c')">multipart monograph</xsl:when>
 						<xsl:when test="$leader7='m' and ($leader19='#')">single unit</xsl:when>
 						<xsl:when test="$leader7='i'">integrating resource</xsl:when>
 						<xsl:when test="$leader7='b' or $leader7='s'">serial</xsl:when>
@@ -1000,23 +1181,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</xsl:for-each>
 
 
-
-
-
 		<xsl:for-each select="marc:datafield[@tag=880]">
-			<xsl:variable name="related_datafield"
-				select="substring-before(marc:subfield[@code='6'],'-')"/>
-			<xsl:variable name="occurence_number"
-				select="substring( substring-after(marc:subfield[@code='6'],'-') , 1 , 2 )"/>
-			<xsl:variable name="hit"
-				select="../marc:datafield[@tag=$related_datafield and contains(marc:subfield[@code='6'] , concat('880-' , $occurence_number))]/@tag"/>
+			<xsl:variable name="related_datafield" select="substring-before(marc:subfield[@code='6'],'-')"/>
+			<xsl:variable name="occurence_number" select="substring( substring-after(marc:subfield[@code='6'],'-') , 1 , 2 )"/>
+			<xsl:variable name="hit" select="../marc:datafield[@tag=$related_datafield and contains(marc:subfield[@code='6'] , concat('880-' , $occurence_number))]/@tag"/>
 
 			<xsl:choose>
 				<xsl:when test="$hit='260'">
 					<originInfo>
 						<xsl:call-template name="scriptCode"/>
-						<xsl:for-each
-							select="../marc:datafield[@tag=260 and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
+						<xsl:for-each select="../marc:datafield[@tag=260 and marc:subfield[@code='a' or code='b' or @code='c' or code='g']]">
 							<xsl:call-template name="z2xx880"/>
 						</xsl:for-each>
 						<xsl:if test="marc:subfield[@code='a']">
@@ -1041,8 +1215,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="marc:subfield[@code='g']"/>
 							</dateCreated>
 						</xsl:if>
-						<xsl:for-each
-							select="../marc:datafield[@tag=880]/marc:subfield[@code=6][contains(text(),'250')]">
+						<xsl:for-each select="../marc:datafield[@tag=880]/marc:subfield[@code=6][contains(text(),'250')]">
 							<edition>
 								<xsl:value-of select="following-sibling::marc:subfield"/>
 							</edition>
@@ -1072,15 +1245,13 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:with-param name="codes">a</xsl:with-param>
 							</xsl:call-template>
 						</form>
-	
 					</physicalDescription>
 				</xsl:when>
 			</xsl:choose>
 		</xsl:for-each>
 
 		<!-- language 041 -->
-		<xsl:variable name="controlField008-35-37"
-			select="normalize-space(translate(substring($controlField008,36,3),'|#',''))"/>
+		<xsl:variable name="controlField008-35-37" select="normalize-space(translate(substring($controlField008,36,3),'|#',''))"/>
 		<xsl:if test="$controlField008-35-37">
 			<language>
 				<languageTerm authority="iso639-2b" type="code">
@@ -1089,8 +1260,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</language>
 		</xsl:if>
 		<xsl:for-each select="marc:datafield[@tag=041]">
-			<xsl:for-each
-				select="marc:subfield[@code='a' or @code='b' or @code='d' or @code='e' or @code='f' or @code='g' or @code='h']">
+			<xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='d' or @code='e' or @code='f' or @code='g' or @code='h']">
 				<xsl:variable name="langCodes" select="."/>
 				<xsl:choose>
 					<xsl:when test="../marc:subfield[@code='2']='rfc3066'">
@@ -1120,9 +1290,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="substring($allLanguages,1,3)"/>
 							</xsl:with-param>
 							<xsl:with-param name="remainingLanguages">
-								<xsl:value-of
-									select="substring($allLanguages,4,string-length($allLanguages)-3)"
-								/>
+								<xsl:value-of select="substring($allLanguages,4,string-length($allLanguages)-3)"/>
 							</xsl:with-param>
 							<xsl:with-param name="usedLanguages">
 								<xsl:if test="$controlField008-35-37">
@@ -1151,8 +1319,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:variable name="controlField008-23" select="substring($controlField008,24,1)"/>
 			<xsl:variable name="controlField008-29" select="substring($controlField008,30,1)"/>
 			<xsl:variable name="check008-23">
-				<xsl:if
-					test="$typeOf008='BK' or $typeOf008='MU' or $typeOf008='SE' or $typeOf008='MM'">
+				<xsl:if test="$typeOf008='BK' or $typeOf008='MU' or $typeOf008='SE' or $typeOf008='MM'">
 					<xsl:value-of select="true()"/>
 				</xsl:if>
 			</xsl:variable>
@@ -1162,28 +1329,23 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:if>
 			</xsl:variable>
 			<xsl:choose>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='f') or ($check008-29 and $controlField008-29='f')">
+				<xsl:when test="($check008-23 and $controlField008-23='f') or ($check008-29 and $controlField008-29='f')">
 					<form authority="marcform">braille</form>
 				</xsl:when>
-				<xsl:when
-					test="($controlField008-23=' ' and ($leader6='c' or $leader6='d')) or (($typeOf008='BK' or $typeOf008='SE') and ($controlField008-23=' ' or $controlField008='r'))">
+				<xsl:when test="($controlField008-23=' ' and ($leader6='c' or $leader6='d')) or (($typeOf008='BK' or $typeOf008='SE') and ($controlField008-23=' ' or $controlField008='r'))">
 					<form authority="marcform">print</form>
 				</xsl:when>
-				<xsl:when
-					test="$leader6 = 'm' or ($check008-23 and $controlField008-23='s') or ($check008-29 and $controlField008-29='s')">
+				<xsl:when test="$leader6 = 'm' or ($check008-23 and $controlField008-23='s') or ($check008-29 and $controlField008-29='s')">
 					<form authority="marcform">electronic</form>
 				</xsl:when>
 				<!-- 1.33 -->
 				<xsl:when test="$leader6 = 'o'">
 					<form authority="marcform">kit</form>
 				</xsl:when>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='b') or ($check008-29 and $controlField008-29='b')">
+				<xsl:when test="($check008-23 and $controlField008-23='b') or ($check008-29 and $controlField008-29='b')">
 					<form authority="marcform">microfiche</form>
 				</xsl:when>
-				<xsl:when
-					test="($check008-23 and $controlField008-23='a') or ($check008-29 and $controlField008-29='a')">
+				<xsl:when test="($check008-23 and $controlField008-23='a') or ($check008-29 and $controlField008-29='a')">
 					<form authority="marcform">microfilm</form>
 				</xsl:when>
 			</xsl:choose>
@@ -1193,8 +1355,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=130]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=130]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1203,8 +1364,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=240]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=240]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1213,8 +1373,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=242]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=242]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1223,8 +1382,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=245]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=245]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1233,8 +1391,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=246]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=246]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1243,8 +1400,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<form authority="gmd">
 					<xsl:call-template name="chopBrackets">
 						<xsl:with-param name="chopString">
-							<xsl:value-of select="marc:datafield[@tag=730]/marc:subfield[@code='h']"
-							/>
+							<xsl:value-of select="marc:datafield[@tag=730]/marc:subfield[@code='h']"/>
 						</xsl:with-param>
 					</xsl:call-template>
 				</form>
@@ -1268,367 +1424,295 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</xsl:choose>
 			</xsl:for-each>
 			<!--3.2 change tmee 007/01 -->
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='b']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">chip cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='c']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">computer optical disc cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='j']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">magnetic disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='m']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='m']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">magneto-optical disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='o']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">optical disc</form>
 			</xsl:if>
 
 			<!-- 1.38 AQ 1.29 tmee 	1.66 added marccategory and marcsmd as part of 3.4 -->
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='r']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">remote</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='a']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='f']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='h']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='c'][substring(text(),2,1)='h']">
 				<form authority="marccategory">electronic resource</form>
 				<form authority="marcsmd">tape reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='a']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">celestial globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='e']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">earth moon globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='b']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">planetary or lunar globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='d'][substring(text(),2,1)='c']">
 				<form authority="marccategory">globe</form>
 				<form authority="marcsmd">terrestrial globe</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='o'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='o'][substring(text(),2,1)='o']">
 				<form authority="marccategory">kit</form>
 				<form authority="marcsmd">kit</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='d']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">atlas</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='g']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">diagram</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='j']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">map</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='q']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">model</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='k']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='k']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">profile</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='r']">
 				<form authority="marcsmd">remote-sensing image</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='s']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">section</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='y']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='a'][substring(text(),2,1)='y']">
 				<form authority="marccategory">map</form>
 				<form authority="marcsmd">view</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='a']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">aperture card</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='e']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfiche</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='f']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfiche cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='b']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='c']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='d']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microfilm reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='h'][substring(text(),2,1)='g']">
 				<form authority="marccategory">microform</form>
 				<form authority="marcsmd">microopaque</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='c']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='f']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='m'][substring(text(),2,1)='r']">
 				<form authority="marccategory">motion picture</form>
 				<form authority="marcsmd">film reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='n']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='n']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">chart</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='c']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">collage</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='d']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">drawing</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='o']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">flash card</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='e']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">painting</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='f']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photomechanical print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='g']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photonegative</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='h']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='h']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">photoprint</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='i']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='i']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">picture</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='j']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='j']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='l']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='k'][substring(text(),2,1)='l']">
 				<form authority="marccategory">nonprojected graphic</form>
 				<form authority="marcsmd">technical drawing</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='q'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='q'][substring(text(),2,1)='q']">
 				<form authority="marccategory">notated music</form>
 				<form authority="marcsmd">notated music</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='d']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmslip</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='c']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmstrip cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='o']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='o']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">filmstrip roll</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='f']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">other filmstrip type</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='s']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">slide</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='t']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='g'][substring(text(),2,1)='t']">
 				<form authority="marccategory">projected graphic</form>
 				<form authority="marcsmd">transparency</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='r'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='r'][substring(text(),2,1)='r']">
 				<form authority="marccategory">remote-sensing image</form>
 				<form authority="marcsmd">remote-sensing image</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='e']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='e']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">cylinder</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='q']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='q']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">roll</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='g']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='g']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound cartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='s']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='s']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound cassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='d']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound disc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='t']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='t']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound-tape reel</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='i']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='i']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">sound-track film</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='w']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='s'][substring(text(),2,1)='w']">
 				<form authority="marccategory">sound recording</form>
 				<form authority="marcsmd">wire recording</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='c']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">braille</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='b']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">combination</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='a']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">moon</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='f'][substring(text(),2,1)='d']">
 				<form authority="marccategory">tactile material</form>
 				<form authority="marcsmd">tactile, with no writing system</form>
 			</xsl:if>
 
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='c']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">braille</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='b']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='b']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">large print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='a']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='a']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">regular print</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='t'][substring(text(),2,1)='d']">
 				<form authority="marccategory">text</form>
 				<form authority="marcsmd">text in looseleaf binder</form>
 			</xsl:if>
 
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='c']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='c']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videocartridge</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='f']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='f']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videocassette</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='d']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='d']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videodisc</form>
 			</xsl:if>
-			<xsl:if
-				test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='r']">
+			<xsl:if test="marc:controlfield[@tag=007][substring(text(),1,1)='v'][substring(text(),2,1)='r']">
 				<form authority="marccategory">videorecording</form>
 				<form authority="marcsmd">videoreel</form>
 			</xsl:if>
 
-			<xsl:for-each
-				select="marc:datafield[@tag=856]/marc:subfield[@code='q'][string-length(.)&gt;1]">
+			<xsl:for-each select="marc:datafield[@tag=856]/marc:subfield[@code='q'][string-length(.)&gt;1]">
 				<internetMediaType>
 					<xsl:value-of select="."/>
 				</internetMediaType>
@@ -1636,8 +1720,15 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 			<xsl:for-each select="marc:datafield[@tag=300]">
 				<extent>
+					<xsl:if test="marc:subfield[@code='f']">
+						<xsl:attribute name="unit">
+							<xsl:call-template name="subfieldSelect">
+								<xsl:with-param name="codes">f</xsl:with-param>
+							</xsl:call-template>
+						</xsl:attribute>
+					</xsl:if>
 					<xsl:call-template name="subfieldSelect">
-						<xsl:with-param name="codes">abce3fg</xsl:with-param>
+						<xsl:with-param name="codes">abce3g</xsl:with-param>
 					</xsl:call-template>
 				</extent>
 			</xsl:for-each>
@@ -1736,8 +1827,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:when test="$controlField008-22='g'">
 					<targetAudience authority="marctarget">general</targetAudience>
 				</xsl:when>
-				<xsl:when
-					test="$controlField008-22='b' or $controlField008-22='c' or $controlField008-22='j'">
+				<xsl:when test="$controlField008-22='b' or $controlField008-22='c' or $controlField008-22='j'">
 					<targetAudience authority="marctarget">juvenile</targetAudience>
 				</xsl:when>
 				<xsl:when test="$controlField008-22='a'">
@@ -1863,8 +1953,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="createNoteFrom585"/>
 		</xsl:for-each>
 
-		<xsl:for-each
-			select="marc:datafield[@tag=501 or @tag=507 or @tag=513 or @tag=514 or @tag=516 or @tag=522 or @tag=525 or @tag=526 or @tag=544 or @tag=547 or @tag=550 or @tag=552 or @tag=555 or @tag=556 or @tag=565 or @tag=567 or @tag=580 or @tag=584 or @tag=586]">
+		<xsl:for-each select="marc:datafield[@tag=501 or @tag=507 or @tag=513 or @tag=514 or @tag=516 or @tag=522 or @tag=525 or @tag=526 or @tag=544 or @tag=547 or @tag=550 or @tag=552 or @tag=555 or @tag=556 or @tag=565 or @tag=567 or @tag=580 or @tag=584 or @tag=586]">
 			<xsl:call-template name="createNoteFrom5XX"/>
 		</xsl:for-each>
 
@@ -2205,8 +2294,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<!-- AQ1.5, AQ1.7 deleted tags 777 and 787 from the following select for relatedItem mapping -->
 		<!-- 1.45 and 1.46 - AQ1.24 and 1.25 tmee-->
-		<xsl:for-each
-			select="marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=775]">
+		<xsl:for-each select="marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=775]">
 			<relatedItem type="otherVersion">
 				<xsl:call-template name="relatedItem76X-78X"/>
 			</relatedItem>
@@ -2490,21 +2578,17 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</identifier>
 		</xsl:for-each>
 
-		<xsl:for-each
-			select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(OCoLC)')]]">
+		<xsl:for-each select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(OCoLC)')]]">
 			<identifier type="oclc">
-				<xsl:value-of
-					select="normalize-space(substring-after(marc:subfield[@code='a'], '(OCoLC)'))"/>
+				<xsl:value-of select="normalize-space(substring-after(marc:subfield[@code='a'], '(OCoLC)'))"/>
 			</identifier>
 		</xsl:for-each>
 		
 		
 		<!-- 3.5 1.95 20140421 -->
-		<xsl:for-each
-			select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(WlCaITV)')]]">
+		<xsl:for-each select="marc:datafield[@tag='035'][marc:subfield[@code='a'][contains(text(), '(WlCaITV)')]]">
 			<identifier type="WlCaITV">
-				<xsl:value-of
-					select="normalize-space(substring-after(marc:subfield[@code='a'], '(WlCaITV)'))"/>
+				<xsl:value-of select="normalize-space(substring-after(marc:subfield[@code='a'], '(WlCaITV)'))"/>
 			</identifier>
 		</xsl:for-each>
 
@@ -2526,24 +2610,16 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<!-- 1.51 tmee 20100129-->
 		<xsl:for-each select="marc:datafield[@tag='856'][marc:subfield[@code='u']]">
-			<xsl:if
-				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
+			<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov') ">
 				<identifier>
 					<xsl:attribute name="type">
-						<xsl:if
-							test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')"
-							>doi</xsl:if>
-						<xsl:if
-							test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')"
-							>hdl</xsl:if>
+						<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:doi') or starts-with(marc:subfield[@code='u'],'doi')">doi</xsl:if>
+						<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl') or starts-with(marc:subfield[@code='u'],'http://hdl.loc.gov')">hdl</xsl:if>
 					</xsl:attribute>
-					<xsl:value-of
-						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
-					/>
+					<xsl:value-of select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"/>
 				</identifier>
 			</xsl:if>
-			<xsl:if
-				test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
+			<xsl:if test="starts-with(marc:subfield[@code='u'],'urn:hdl') or starts-with(marc:subfield[@code='u'],'hdl')">
 				<identifier type="hdl">
 					<xsl:if test="marc:subfield[@code='y' or @code='3' or @code='z']">
 						<xsl:attribute name="displayLabel">
@@ -2552,9 +2628,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							</xsl:call-template>
 						</xsl:attribute>
 					</xsl:if>
-					<xsl:value-of
-						select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"
-					/>
+					<xsl:value-of select="concat('hdl:',substring-after(marc:subfield[@code='u'],'http://hdl.loc.gov/'))"/>
 				</identifier>
 			</xsl:if>
 		</xsl:for-each>
@@ -2666,7 +2740,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:for-each>
 
 			<recordOrigin>Converted from MARCXML to MODS version 3.5 using MARC21slim2MODS3-5.xsl
-				(Revision 1.102 2014/08/12)</recordOrigin>
+				(Revision 1.105 2014/11/21)</recordOrigin>
 
 			<xsl:for-each select="marc:datafield[@tag=040]/marc:subfield[@code='b']">
 				<languageOfCataloging>
@@ -2926,8 +3000,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:value-of select="."/>
 			</namePart>
 		</xsl:for-each>
-		<xsl:if
-			test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+		<xsl:if test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
 			<namePart>
 				<xsl:call-template name="subfieldSelect">
 					<xsl:with-param name="codes">cdn</xsl:with-param>
@@ -2958,6 +3031,18 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			</xsl:call-template>
 		</namePart>
 	</xsl:template>
+	
+	<!--1.104 20141104-->
+	<xsl:template name="nameACDENQ">
+		<namePart>
+			<xsl:call-template name="subfieldSelect">
+				<xsl:with-param name="codes">acdenq</xsl:with-param>
+			</xsl:call-template>
+		</namePart>
+	</xsl:template>
+	
+	
+	
 	<xsl:template name="constituentOrRelatedType">
 		<xsl:if test="@ind2=2">
 			<xsl:attribute name="type">constituent</xsl:attribute>
@@ -3155,8 +3240,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:param name="afterCodes"/>
 		<xsl:variable name="str">
 			<xsl:for-each select="marc:subfield">
-				<xsl:if
-					test="contains($anyCodes, @code) or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+				<xsl:if test="contains($anyCodes, @code) or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
 					<xsl:value-of select="text()"/>
 					<xsl:text> </xsl:text>
 				</xsl:if>
@@ -3427,9 +3511,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
 					</xsl:with-param>
 					<xsl:with-param name="remainingLanguages">
-						<xsl:value-of
-							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
-						/>
+						<xsl:value-of select="substring($remainingLanguages,4,string-length($remainingLanguages))"/>
 					</xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>
@@ -3442,9 +3524,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 						<xsl:value-of select="concat($usedLanguages,$currentLanguage)"/>
 					</xsl:with-param>
 					<xsl:with-param name="remainingLanguages">
-						<xsl:value-of
-							select="substring($remainingLanguages,4,string-length($remainingLanguages))"
-						/>
+						<xsl:value-of select="substring($remainingLanguages,4,string-length($remainingLanguages))"/>
 					</xsl:with-param>
 				</xsl:call-template>
 			</xsl:otherwise>
@@ -3471,8 +3551,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="currentLanguage" select="."/>
 		<xsl:choose>
 			<xsl:when test="not($currentLanguage)"/>
-			<xsl:when
-				test="$currentLanguage!=$controlField008-35-37 and $currentLanguage!='rfc3066'">
+			<xsl:when test="$currentLanguage!=$controlField008-35-37 and $currentLanguage!='rfc3066'">
 				<xsl:if test="not(contains($usedLanguages,$currentLanguage))">
 					<language>
 						<xsl:if test="@code!='a'">
@@ -3571,8 +3650,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 	<xsl:template name="yyy880">
 		<xsl:if test="preceding-sibling::marc:subfield[@code='6']">
-			<xsl:variable name="sf06"
-				select="normalize-space(preceding-sibling::marc:subfield[@code='6'])"/>
+			<xsl:variable name="sf06" select="normalize-space(preceding-sibling::marc:subfield[@code='6'])"/>
 			<xsl:variable name="sf06a" select="substring($sf06, 1, 3)"/>
 			<xsl:variable name="sf06b" select="substring($sf06, 5, 2)"/>
 			<xsl:variable name="sf06c" select="substring($sf06, 7)"/>
@@ -3589,17 +3667,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x260">
 			<xsl:choose>
 				<xsl:when test="@tag='260' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06260"
-						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06260" select="normalize-space(child::marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
 					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
 					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
 					<xsl:value-of select="$sf06260b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='250' and ../marc:datafield[@tag='260']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06260"
-						select="normalize-space(../marc:datafield[@tag='260']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='250' and ../marc:datafield[@tag='260']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06260" select="normalize-space(../marc:datafield[@tag='260']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06260a" select="substring($sf06260, 1, 3)"/>
 					<xsl:variable name="sf06260b" select="substring($sf06260, 5, 2)"/>
 					<xsl:variable name="sf06260c" select="substring($sf06260, 7)"/>
@@ -3611,17 +3686,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x250">
 			<xsl:choose>
 				<xsl:when test="@tag='250' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06250"
-						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06250" select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
 					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
 					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
 					<xsl:value-of select="$sf06250b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='260' and ../marc:datafield[@tag='250']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06250"
-						select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='260' and ../marc:datafield[@tag='250']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06250" select="normalize-space(../marc:datafield[@tag='250']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06250a" select="substring($sf06250, 1, 3)"/>
 					<xsl:variable name="sf06250b" select="substring($sf06250, 5, 2)"/>
 					<xsl:variable name="sf06250c" select="substring($sf06250, 7)"/>
@@ -3655,17 +3727,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x300">
 			<xsl:choose>
 				<xsl:when test="@tag='300' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06300"
-						select="normalize-space(child::marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06300" select="normalize-space(child::marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
 					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
 					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
 					<xsl:value-of select="$sf06300b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='351' and ../marc:datafield[@tag='300']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06300"
-						select="normalize-space(../marc:datafield[@tag='300']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='351' and ../marc:datafield[@tag='300']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06300" select="normalize-space(../marc:datafield[@tag='300']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06300a" select="substring($sf06300, 1, 3)"/>
 					<xsl:variable name="sf06300b" select="substring($sf06300, 5, 2)"/>
 					<xsl:variable name="sf06300c" select="substring($sf06300, 7)"/>
@@ -3677,17 +3746,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		<xsl:variable name="x351">
 			<xsl:choose>
 				<xsl:when test="@tag='351' and marc:subfield[@code='6']">
-					<xsl:variable name="sf06351"
-						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+					<xsl:variable name="sf06351" select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
 					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
 					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
 					<xsl:value-of select="$sf06351b"/>
 				</xsl:when>
-				<xsl:when
-					test="@tag='300' and ../marc:datafield[@tag='351']/marc:subfield[@code='6']">
-					<xsl:variable name="sf06351"
-						select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
+				<xsl:when test="@tag='300' and ../marc:datafield[@tag='351']/marc:subfield[@code='6']">
+					<xsl:variable name="sf06351" select="normalize-space(../marc:datafield[@tag='351']/marc:subfield[@code='6'])"/>
 					<xsl:variable name="sf06351a" select="substring($sf06351, 1, 3)"/>
 					<xsl:variable name="sf06351b" select="substring($sf06351, 5, 2)"/>
 					<xsl:variable name="sf06351c" select="substring($sf06351, 7)"/>
@@ -3698,8 +3764,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 		<xsl:variable name="x337">
 			<xsl:if test="@tag='337' and marc:subfield[@code='6']">
-				<xsl:variable name="sf06337"
-					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06337" select="normalize-space(child::marc:subfield[@code='6'])"/>
 				<xsl:variable name="sf06337a" select="substring($sf06337, 1, 3)"/>
 				<xsl:variable name="sf06337b" select="substring($sf06337, 5, 2)"/>
 				<xsl:variable name="sf06337c" select="substring($sf06337, 7)"/>
@@ -3708,8 +3773,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</xsl:variable>
 		<xsl:variable name="x338">
 			<xsl:if test="@tag='338' and marc:subfield[@code='6']">
-				<xsl:variable name="sf06338"
-					select="normalize-space(child::marc:subfield[@code='6'])"/>
+				<xsl:variable name="sf06338" select="normalize-space(child::marc:subfield[@code='6'])"/>
 				<xsl:variable name="sf06338a" select="substring($sf06338, 1, 3)"/>
 				<xsl:variable name="sf06338b" select="substring($sf06338, 5, 2)"/>
 				<xsl:variable name="sf06338c" select="substring($sf06338, 7)"/>
@@ -4065,8 +4129,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 								<xsl:value-of select="text()"/>
 								<xsl:text> </xsl:text>
 							</xsl:if>
-							<xsl:if
-								test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+							<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 								<xsl:value-of select="text()"/>
 								<xsl:text> </xsl:text>
 							</xsl:if>
@@ -4091,8 +4154,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
-						<xsl:if
-							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+						<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
@@ -4216,8 +4278,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 
 	<xsl:template name="createTitleInfoFrom240">
 		<titleInfo type="uniform">
-			<xsl:if
-				test="//marc:datafield[@tag='100']|//marc:datafield[@tag='110']|//marc:datafield[@tag='111']">
+			<xsl:if test="//marc:datafield[@tag='100']|//marc:datafield[@tag='110']|//marc:datafield[@tag='111']">
 				<xsl:attribute name="nameTitleGroup">
 					<xsl:text>1</xsl:text>
 				</xsl:attribute>
@@ -4226,8 +4287,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<title>
 				<xsl:variable name="str">
 					<xsl:for-each select="marc:subfield">
-						<xsl:if
-							test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
+						<xsl:if test="(contains('adfklmors',@code) and (not(../marc:subfield[@code='n' or @code='p']) or (following-sibling::marc:subfield[@code='n' or @code='p'])))">
 							<xsl:value-of select="text()"/>
 							<xsl:text> </xsl:text>
 						</xsl:if>
@@ -4311,6 +4371,9 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</name>
 	</xsl:template>
 
+
+	<!-- 111 1.104 20141104 -->
+
 	<xsl:template name="createNameFrom111">
 		<name type="conference">
 			<xsl:call-template name="xxx880"/>
@@ -4319,7 +4382,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					<xsl:text>1</xsl:text>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="nameACDENQ"/>
 			<xsl:call-template name="role"/>
 		</name>
 	</xsl:template>
@@ -4355,10 +4418,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 		</name>
 	</xsl:template>
 
+<!-- 111 1.104 20141104 -->
 	<xsl:template name="createNameFrom711">
 		<name type="conference">
 			<xsl:call-template name="xxx880"/>
-			<xsl:call-template name="nameACDEQ"/>
+			<xsl:call-template name="nameACDENQ"/>
 			<xsl:call-template name="role"/>
 		</name>
 	</xsl:template>
@@ -4569,8 +4633,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="xxx880"/>
 			<xsl:call-template name="uri"/>
 			<xsl:variable name="str">
-				<xsl:for-each
-					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+				<xsl:for-each select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
 					<xsl:value-of select="."/>
 					<xsl:text> </xsl:text>
 				</xsl:for-each>
@@ -4640,8 +4703,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 			<xsl:call-template name="xxx880"/>
 			<xsl:call-template name="uri"/>
 			<xsl:variable name="str">
-				<xsl:for-each
-					select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
+				<xsl:for-each select="marc:subfield[@code!='u' and @code!='3' and @code!='6' and @code!='8']">
 					<xsl:value-of select="."/>
 					<xsl:text> </xsl:text>
 				</xsl:for-each>
@@ -4851,8 +4913,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	<!-- subject Geo 034 043 045 255 656 662 752 -->
 
 	<xsl:template name="createSubGeoFrom034">
-		<xsl:if
-			test="marc:datafield[@tag=034][marc:subfield[@code='d' or @code='e' or @code='f' or @code='g']]">
+		<xsl:if test="marc:datafield[@tag=034][marc:subfield[@code='d' or @code='e' or @code='f' or @code='g']]">
 			<subject>
 				<xsl:call-template name="xxx880"/>
 				<cartographics>
@@ -5256,20 +5317,17 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	</xsl:template>
 
 	<xsl:template name="createSubTemFrom045">
-		<xsl:if
-			test="//marc:datafield[@tag=045 and @ind1='2'][marc:subfield[@code='b' or @code='c']]">
+		<xsl:if test="//marc:datafield[@tag=045 and @ind1='2'][marc:subfield[@code='b' or @code='c']]">
 			<subject>
 				<xsl:call-template name="xxx880"/>
 				<temporal encoding="iso8601" point="start">
 					<xsl:call-template name="dates045b">
-						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][1]"
-						/>
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][1]"/>
 					</xsl:call-template>
 				</temporal>
 				<temporal encoding="iso8601" point="end">
 					<xsl:call-template name="dates045b">
-						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][2]"
-						/>
+						<xsl:with-param name="str" select="marc:subfield[@code='b' or @code='c'][2]"/>
 					</xsl:call-template>
 				</temporal>
 			</subject>
@@ -5292,8 +5350,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				<xsl:value-of select="text()"/>
 			</classification>
 		</xsl:for-each>
-		<xsl:for-each
-			select="marc:subfield[@code='a'][not(following-sibling::marc:subfield[@code='b'])]">
+		<xsl:for-each select="marc:subfield[@code='a'][not(following-sibling::marc:subfield[@code='b'])]">
 			<classification authority="lcc">
 				<xsl:call-template name="xxx880"/>
 				<xsl:if test="../marc:subfield[@code='3']">
@@ -5412,8 +5469,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 				</physicalLocation>
 			</xsl:if>
 			<!-- 1.78 -->
-			<xsl:if
-				test="marc:subfield[@code='h' or @code='i' or @code='j' or @code='k' or @code='l' or @code='m' or @code='t']">
+			<xsl:if test="marc:subfield[@code='h' or @code='i' or @code='j' or @code='k' or @code='l' or @code='m' or @code='t']">
 				<shelfLocator>
 					<xsl:call-template name="subfieldSelect">
 						<xsl:with-param name="codes">hijklmt</xsl:with-param>
@@ -5430,23 +5486,11 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					<!-- 1.41 tmee AQ1.9 added choice protocol for @usage="primary display" -->
 					<xsl:variable name="primary">
 						<xsl:choose>
-							<xsl:when
-								test="@ind2=0 and count(preceding-sibling::marc:datafield[@tag=856] [@ind2=0])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2=0 and count(preceding-sibling::marc:datafield[@tag=856] [@ind2=0])=0">true</xsl:when>
 
-							<xsl:when
-								test="@ind2=1 and 
-							count(ancestor::marc:record//marc:datafield[@tag=856][@ind2=0])=0 and 
-							count(preceding-sibling::marc:datafield[@tag=856][@ind2=1])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2=1 and         count(ancestor::marc:record//marc:datafield[@tag=856][@ind2=0])=0 and         count(preceding-sibling::marc:datafield[@tag=856][@ind2=1])=0">true</xsl:when>
 
-							<xsl:when
-								test="@ind2!=1 and @ind2!=0 and 
-							@ind2!=2 and count(ancestor::marc:record//marc:datafield[@tag=856 and 
-							@ind2=0])=0 and count(ancestor::marc:record//marc:datafield[@tag=856 and 
-							@ind2=1])=0 and 
-							count(preceding-sibling::marc:datafield[@tag=856][@ind2])=0"
-								>true</xsl:when>
+							<xsl:when test="@ind2!=1 and @ind2!=0 and         @ind2!=2 and count(ancestor::marc:record//marc:datafield[@tag=856 and         @ind2=0])=0 and count(ancestor::marc:record//marc:datafield[@tag=856 and         @ind2=1])=0 and         count(preceding-sibling::marc:datafield[@tag=856][@ind2])=0">true</xsl:when>
 							<xsl:otherwise>false</xsl:otherwise>
 						</xsl:choose>
 					</xsl:variable>


### PR DESCRIPTION
"The Library of Congress' MARCXML to MODS 3.5 (XSLT 1.0 Revision 1.104) is now available via the Library of Congress' MODS Web site and at <http://www.loc.gov/standards/mods/v3/MARC21slim2MODS3-5.xsl >--it incorporates edits made in response to comments received since the release of Revision 1.102."
