### PR TITLE
Add ability to upload a new copy of MARCXML to transform MODS on an e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-There are no configuration options available for the MARCXML module in Drupal. Enabling the module adds the MARCXML tab to all solution packs for all users with permissions to view Fedora objects, and makes the MARCXML upload option available for all content models during ingest.
+This module provides the ability to optionally allow a user to re-transform a MARCXML file to MODS after initial upload. This is configurable in Administration » Islandora » Islandora Utility Modules » Islandora MARCXML (admin/islandora/tools/islandora_marcxml).
 
 Permissions to control who may _View MARCXML output_ are available at Administration » People » Permissions (admin/people/permissions).
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Adminstration settings for the Islandora MARCXML module.
+ */
+
+/**
+ * Adminstration form for the Islandora MARCXML module.
+ */
+function islandora_marcxml_admin_settings(array $form, array &$form_state) {
+  $form['islandora_marcxml_allow_editing_of_existing_mods'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow user to upload a new copy of the MARCXML to be re-transformed and stored as MODS.'),
+    '#description' => t("This provides an extra option to be available under the 'edit' link present on objects that have MODS datastreams."),
+    '#default_value' => variable_get('islandora_marcxml_allow_editing_of_existing_mods', FALSE),
+  );
+  return system_settings_form($form);
+}

--- a/includes/edit.form.inc
+++ b/includes/edit.form.inc
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Upload MARCXML file.
+ */
+
+/**
+ * Upload MARCXML form.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ * @param AbstractObject $object
+ *   A object within Fedora.
+ *
+ * @return array
+ *   A Drupal form definition.
+ */
+function islandora_marcxml_edit_file_form(array $form, array &$form_state, AbstractObject $object) {
+  $form = array();
+  $form['file'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('MARCXML File'),
+    '#description' => t('A file containing a MARCXML record, to be transformed to MODS.'),
+    '#upload_validators' => array(
+      'file_validate_extensions' => array('xml'),
+    ),
+    '#required' => TRUE,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Update'),
+  );
+  return $form;
+}
+
+/**
+ * Populate the MODS datastream with the transformed MARCXML.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_marcxml_edit_file_form_submit(array &$form, array &$form_state) {
+  module_load_include('inc', 'islandora_marcxml', 'includes/utilities');
+  $file = file_load($form_state['values']['file']);
+  $object = islandora_object_load($form_state['build_info']['args'][0]->id);
+  islandora_marcxml_populate_mods($object, $file);
+  file_delete($file);
+  drupal_set_message(t('The MODS datastream has been updated from the uploaded MARCXML.'));
+  $form_state['redirect'] = "islandora/object/{$object->id}";
+}

--- a/includes/edit.form.inc
+++ b/includes/edit.form.inc
@@ -37,6 +37,26 @@ function islandora_marcxml_edit_file_form(array $form, array &$form_state, Abstr
 }
 
 /**
+ * Validation to ensure the uploaded XML is valid MARCXML.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_marcxml_edit_file_form_validate(array $form, array &$form_state) {
+  $file = file_load($form_state['values']['file']);
+  // Validate that the two elements the XSL looks for are present.
+  $dom = new DOMDocument();
+  $dom->load(drupal_realpath($file->uri));
+  $dom_xpath = new DOMXPath($dom);
+  $dom_xpath->registerNamespace('marc', 'http://www.loc.gov/MARC21/slim');
+  if (!$dom_xpath->evaluate('boolean(//marc:collection|//marc:record)')) {
+    form_error($form['file'], t('The uploaded XML is not valid MARCXML.'));
+  }
+}
+
+/**
  * Populate the MODS datastream with the transformed MARCXML.
  *
  * @param array $form

--- a/includes/edit.form.inc
+++ b/includes/edit.form.inc
@@ -2,11 +2,11 @@
 
 /**
  * @file
- * Upload MARCXML file.
+ * Form functions for editing a MODS datastream by re-transforming MARCXML.
  */
 
 /**
- * Upload MARCXML form.
+ * Form to allow editing of an existing MODS datastream.
  *
  * @param array $form
  *   The Drupal form.

--- a/islandora_marcxml.module
+++ b/islandora_marcxml.module
@@ -32,6 +32,14 @@ function islandora_marcxml_menu() {
       'delivery callback' => 'islandora_marcxml_xml_download',
       'file' => 'includes/utilities.inc',
     ),
+    'islandora/object/%islandora_object/update_mods_from_marcxml' => array(
+      'title' => 'Update MODS',
+      'description' => 'Updates the MODS datastream from a new MARCXML source.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_marcxml_edit_file_form', 2),
+      'access arguments' => array(ISLANDORA_METADATA_EDIT),
+      'file' => 'includes/edit.form.inc',
+    ),
   );
 }
 
@@ -95,5 +103,19 @@ function islandora_marcxml_islandora_ingest_steps_alter(array &$steps, array &$f
         'module' => 'islandora_marcxml',
       );
     }
+  }
+}
+
+/**
+ * Implements hook_islandora_edit_datastream_registry().
+ */
+function islandora_marcxml_islandora_edit_datastream_registry(AbstractObject $object, AbstractDatastream $datastream) {
+  if ($datastream->id == 'MODS') {
+    return array(
+      'islandora_marcxml_update_mods_from_marcxml' => array(
+        'name' => t('Update MODS from MARCXML'),
+        'url' => "islandora/object/{$object->id}/update_mods_from_marcxml",
+      ),
+    );
   }
 }

--- a/islandora_marcxml.module
+++ b/islandora_marcxml.module
@@ -37,8 +37,17 @@ function islandora_marcxml_menu() {
       'description' => 'Updates the MODS datastream from a new MARCXML source.',
       'page callback' => 'drupal_get_form',
       'page arguments' => array('islandora_marcxml_edit_file_form', 2),
-      'access arguments' => array(ISLANDORA_METADATA_EDIT),
+      'access callback' => 'islandora_marcxml_update_access_callback',
+      'access arguments' => array(2),
       'file' => 'includes/edit.form.inc',
+    ),
+    'admin/islandora/tools/islandora_marcxml' => array(
+      'title' => 'Islandora MARCXML',
+      'description' => 'Configure settings for the Bookmark module.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_marcxml_admin_settings'),
+      'access arguments' => array('administer site configuration'),
+      'file' => 'includes/admin.form.inc',
     ),
   );
 }
@@ -88,6 +97,20 @@ function islandora_marcxml_access_callback($object) {
 }
 
 /**
+ * Callback for re-transforming a MARCXML file and storing in MODS.
+ *
+ * @param AbstractObject $object
+ *   An object attempting to have its MODS updated.
+ *
+ * @return bool
+ *   TRUE if the user has access to the object and the ability to update, FALSE
+ *   otherwise.
+ */
+function islandora_marcxml_update_access_callback(AbstractObject $object) {
+  return variable_get('islandora_marcxml_allow_editing_of_existing_mods', FALSE) && islandora_object_access(ISLANDORA_METADATA_EDIT, $object);
+}
+
+/**
  * Implements hook_islandora_ingest_steps_alter().
  */
 function islandora_marcxml_islandora_ingest_steps_alter(array &$steps, array &$form_state) {
@@ -110,7 +133,7 @@ function islandora_marcxml_islandora_ingest_steps_alter(array &$steps, array &$f
  * Implements hook_islandora_edit_datastream_registry().
  */
 function islandora_marcxml_islandora_edit_datastream_registry(AbstractObject $object, AbstractDatastream $datastream) {
-  if ($datastream->id == 'MODS') {
+  if (variable_get('islandora_marcxml_allow_editing_of_existing_mods', FALSE) && $datastream->id == 'MODS') {
     return array(
       'islandora_marcxml_update_mods_from_marcxml' => array(
         'name' => t('Update MODS from a user provided MARCXML'),

--- a/islandora_marcxml.module
+++ b/islandora_marcxml.module
@@ -113,7 +113,7 @@ function islandora_marcxml_islandora_edit_datastream_registry(AbstractObject $ob
   if ($datastream->id == 'MODS') {
     return array(
       'islandora_marcxml_update_mods_from_marcxml' => array(
-        'name' => t('Update MODS from MARCXML'),
+        'name' => t('Update MODS from a user provided MARCXML'),
         'url' => "islandora/object/{$object->id}/update_mods_from_marcxml",
       ),
     );


### PR DESCRIPTION
…xisting object.

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1965

# What does this Pull Request do?
Allows a user to upload a new version of the MARCXML to be transformed to MODS and stored on an existing object.

# What's new?
The ability to "update" the MODS by uploading a MARCXML file to be transformed from on an existing object.

# How should this be tested?

Ingest an object with metadata created using the "MARCXML" ingest step.
Go to the datastreams page for that object.
Click the edit link that appears beside the MODS datastream.
Select "Update MODS from MARCXML"
Upload a new MARCXML file.
Ensure that a newly transformed version of the MODS is stored on the object. 

# Additional Notes:

* Does this change require documentation to be updated?  No.
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No.
* Could this change impact execution of existing code? If the user has this module enabled on an object with a formbuilder form associated the datastream registry edit page will force the user to choose which action they wish to do when "editing" an object.

# Interested parties
@Islandora/7-x-1-x-committers
