### PR TITLE
Add toggle to enable and disable marcxml file upload

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,5 +34,11 @@ function islandora_marcxml_admin_settings(array $form, array &$form_state) {
     ),
     '#description' => t('Select the MARC to MODS XSL file to convert your uploaded MARCXML to MODS.'),
   );
+  $form['islandora_marcxml_ingest_step'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Add a MARCXML File ingest step'),
+    '#description' => t('When ingesting objects, provide the option to upload a MARCXML file to populate the ingest form.'),
+    '#default_value' => variable_get('islandora_marcxml_ingest_step', TRUE),
+  );
   return system_settings_form($form);
 }

--- a/includes/file.form.inc
+++ b/includes/file.form.inc
@@ -21,8 +21,7 @@ function islandora_marcxml_file_form(array $form, array &$form_state) {
     'file' => array(
       '#type' => 'managed_file',
       '#title' => t('MARCXML File'),
-      '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.
-        To disable this ingest step, configure the Islandora MARCXML module.'),
+      '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.'),
       '#upload_validators' => array(
         'file_validate_extensions' => array('xml'),
       ),

--- a/includes/file.form.inc
+++ b/includes/file.form.inc
@@ -22,8 +22,7 @@ function islandora_marcxml_file_form(array $form, array &$form_state) {
       '#type' => 'managed_file',
       '#title' => t('MARCXML File'),
       '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.
-        To disable this ingest step, <a href="@url">configure the Islandora MARCXML module.</a>', array('@url' => 'admin/islandora/tools/islandora_marcxml'),
-
+        To disable this ingest step, <a href="@url">configure the Islandora MARCXML module.</a>', array('@url' => url('admin/islandora/tools/islandora_marcxml'))),
       '#upload_validators' => array(
         'file_validate_extensions' => array('xml'),
       ),

--- a/includes/file.form.inc
+++ b/includes/file.form.inc
@@ -21,7 +21,8 @@ function islandora_marcxml_file_form(array $form, array &$form_state) {
     'file' => array(
       '#type' => 'managed_file',
       '#title' => t('MARCXML File'),
-      '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.'),
+      '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.
+        To disable this ingest step, <a href="/admin/islandora/tools/islandora_marcxml">configure the Islandora MARCXML module.</a>'),
       '#upload_validators' => array(
         'file_validate_extensions' => array('xml'),
       ),

--- a/includes/file.form.inc
+++ b/includes/file.form.inc
@@ -22,7 +22,8 @@ function islandora_marcxml_file_form(array $form, array &$form_state) {
       '#type' => 'managed_file',
       '#title' => t('MARCXML File'),
       '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.
-        To disable this ingest step, <a href="/admin/islandora/tools/islandora_marcxml">configure the Islandora MARCXML module.</a>'),
+        To disable this ingest step, <a href="@url">configure the Islandora MARCXML module.</a>', array('@url' => 'admin/islandora/tools/islandora_marcxml'),
+
       '#upload_validators' => array(
         'file_validate_extensions' => array('xml'),
       ),

--- a/includes/file.form.inc
+++ b/includes/file.form.inc
@@ -22,7 +22,7 @@ function islandora_marcxml_file_form(array $form, array &$form_state) {
       '#type' => 'managed_file',
       '#title' => t('MARCXML File'),
       '#description' => t('A file containing a MARCXML record, to be transformed to MODS. Click "Next" to skip this step and create a record from scratch.
-        To disable this ingest step, <a href="@url">configure the Islandora MARCXML module.</a>', array('@url' => url('admin/islandora/tools/islandora_marcxml'))),
+        To disable this ingest step, configure the Islandora MARCXML module.'),
       '#upload_validators' => array(
         'file_validate_extensions' => array('xml'),
       ),

--- a/islandora_marcxml.install
+++ b/islandora_marcxml.install
@@ -10,6 +10,7 @@
 function islandora_marcxml_uninstall() {
   $variables = array(
     'islandora_marcxml_allow_editing_of_existing_mods',
+    'islandora_marcxml_ingest_step',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_marcxml.install
+++ b/islandora_marcxml.install
@@ -23,3 +23,11 @@ function islandora_marcxml_update_7100(&$sandbox) {
   MODS-to-MARCXML and MARCXML-to-MODS XSL files. If you wish to switch back to the old versions, you can select them
   on the module configuration page.')));
 }
+
+/**
+ * Notify the administrator of the new toggle option.
+ */
+function islandora_marcxml_update_7200(&$sandbox) {
+  drupal_set_message(filter_xss(t('A new setting has been added to the Islandora MARCXML configuration form.
+  You may now turn off the ingest step that invites the user to upload a MARCXML file.')));
+}

--- a/islandora_marcxml.module
+++ b/islandora_marcxml.module
@@ -114,17 +114,20 @@ function islandora_marcxml_update_access_callback(AbstractObject $object) {
  * Implements hook_islandora_ingest_steps_alter().
  */
 function islandora_marcxml_islandora_ingest_steps_alter(array &$steps, array &$form_state) {
-  if (isset($steps['xml_form_builder_metadata_step'])) {
-    $association = isset($steps['xml_form_builder_metadata_step']['args'][0]) ? $steps['xml_form_builder_metadata_step']['args'][0] : NULL;
-    if (isset($association['dsid']) && $association['dsid'] == 'MODS') {
-      $steps['islandora_marcxml_upload'] = array(
-        'type' => 'form',
-        'weight' => 1,
-        'form_id' => 'islandora_marcxml_file_form',
-        'args' => array(),
-        'file' => 'includes/file.form.inc',
-        'module' => 'islandora_marcxml',
-      );
+  $add_marcxml = variable_get('islandora_marcxml_ingest_step', TRUE);
+  if ($add_marcxml == TRUE) {
+    if (isset($steps['xml_form_builder_metadata_step'])) {
+      $association = isset($steps['xml_form_builder_metadata_step']['args'][0]) ? $steps['xml_form_builder_metadata_step']['args'][0] : NULL;
+      if (isset($association['dsid']) && $association['dsid'] == 'MODS') {
+        $steps['islandora_marcxml_upload'] = array(
+          'type' => 'form',
+          'weight' => 1,
+          'form_id' => 'islandora_marcxml_file_form',
+          'args' => array(),
+          'file' => 'includes/file.form.inc',
+          'module' => 'islandora_marcxml',
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2452)

https://github.com/Islandora/islandora_importer/pull/117

# What does this Pull Request do?

Adds an admin form toggle to turn on/off the "upload MARCXML file" ingest step.

# What's new?

New option on the form. Defaults to "true" to preserve existing behaviour, but now we can turn off the MARCXML upload step when ingesting.

# How should this be tested?

* Check out this branch
* Enable Islandora Marcxml
* Start ingesting a new object, observe that the MARCXML file upload menu interrupts your ingest
* Configure Islandora Marcxml, turn off this option
* Start ingesting again; observe that the file upload screen is gone

# Interested parties
@DiegoPino @adam-vessey @Islandora/7-x-1-x-committers @willtp87 @whikloj 
